### PR TITLE
Added to RPCError display formatter the data which exactly gives us the error information

### DIFF
--- a/nimiq-jsonrpc-core/src/lib.rs
+++ b/nimiq-jsonrpc-core/src/lib.rs
@@ -284,6 +284,9 @@ impl std::fmt::Display for RpcError {
         if let Some(message) = &self.message {
             write!(f, ": {}", message)?;
         }
+        if let Some(data) = &self.data {
+            write!(f, " - Caused by:  {}", data)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION

It solves https://github.com/nimiq/core-rs-albatross/issues/1168

Example

Before: 
`
Error: JSON-RPC protocol error: The server responded with an error: JSON-RPC error: code=-32603: Internal error 
`
Now:
`
Error: JSON-RPC protocol error: The server responded with an error: JSON-RPC error: code=-32603: Internal error - Caused by:  "Transaction not found: f7aa1555a1bc32aaa8f6dd2fd87b5504984d9a48faa3a7b77dc30ca97c394004"
`