### PR TITLE
Added to RPCError display formatter

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -287,6 +287,9 @@ impl std::fmt::Display for RpcError {
         if let Some(message) = &self.message {
             write!(f, ": {}", message)?;
         }
+        if let Some(data) = &self.data {
+            write!(f, " - Caused by:  {}", data)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
**Originally submitted by @cud4m in #3 **

Closes https://github.com/nimiq/core-rs-albatross/issues/1168

Example

Before: 
`
Error: JSON-RPC protocol error: The server responded with an error: JSON-RPC error: code=-32603: Internal error 
`
Now:
`
Error: JSON-RPC protocol error: The server responded with an error: JSON-RPC error: code=-32603: Internal error - Caused by:  "Transaction not found: f7aa1555a1bc32aaa8f6dd2fd87b5504984d9a48faa3a7b77dc30ca97c394004"
`