### PR TITLE
Better handling of control frames, accept text messages again

### DIFF
--- a/client/src/websocket.rs
+++ b/client/src/websocket.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Debug, str::FromStr, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, fmt::Debug, str::FromStr, sync::Arc};
 
 use async_trait::async_trait;
 use base64::Engine;
@@ -13,7 +13,11 @@ use tokio::{
     net::TcpStream,
     sync::{mpsc, oneshot, RwLock},
 };
-use tokio_tungstenite::tungstenite::{client::IntoClientRequest, Message};
+use tokio_tungstenite::tungstenite::{
+    client::IntoClientRequest,
+    protocol::{frame::coding::CloseCode, CloseFrame},
+    Message,
+};
 use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 use url::Url;
 
@@ -259,6 +263,12 @@ impl Client for WebsocketClient {
     async fn close(&mut self) {
         // Try to send the close message
         // We don't do anything if it fails
-        let _ = self.sender.send(Message::Close(None)).await;
+        let _ = self
+            .sender
+            .send(Message::Close(Some(CloseFrame {
+                code: CloseCode::Normal,
+                reason: Cow::from(""),
+            })))
+            .await;
     }
 }


### PR DESCRIPTION
The previous change in #12 removed the ability to accept text messages, which breaks external RPC clients that do not send binary messages.

Additionally, that change made the server exit uncleanly (with code 1006) in case of any close, ping or pong control frame, which is _non-standard behavior_.

This PR makes the server correctly echo close messages and handle ping and pong without closing the connection. It also accepts text messages again, although it still only sends out binary messages.