### PR TITLE
server: Respond WS text request as text as well

### DIFF
--- a/derive/src/service.rs
+++ b/derive/src/service.rs
@@ -90,7 +90,7 @@ fn impl_service(im: &mut ItemImpl, args: &ServiceMeta) -> TokenStream {
             async fn dispatch(
                 &mut self,
                 request: ::nimiq_jsonrpc_core::Request,
-                tx: Option<&::tokio::sync::mpsc::Sender<::std::vec::Vec<u8>>>,
+                tx: Option<&::tokio::sync::mpsc::Sender<::nimiq_jsonrpc_server::Message>>,
                 stream_id: u64,
             ) -> Option<::nimiq_jsonrpc_core::Response> {
                 match request.method.as_str() {


### PR DESCRIPTION
Make the `ws` server to respond to requests in text when they arrive in text format instead of always replying in binary.