### PR TITLE
Limit HTTP request bodies to 1 MiB

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -206,6 +206,7 @@ impl<D: Dispatcher> Server<D> {
         let inner = Arc::clone(&self.inner);
         let post_route = warp::path::end()
             .and(warp::post())
+            .and(warp::body::content_length_limit(1024 * 1024))
             .and(warp::body::bytes())
             .and_then(move |body: Bytes| {
                 let inner = Arc::clone(&inner);


### PR DESCRIPTION
This stops the RPC server from allocating arbitrary amounts of memory, leading to out of memory crashes.

Fixes https://github.com/nimiq/core-rs-albatross/issues/2749.