### PR TITLE
Return error message to client upon providing incorrect method parameters

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -596,11 +596,7 @@ where
         Ok(params) => params,
         Err(e) => {
             log::error!("{}", e);
-            return error_response(request.id, || {
-                RpcError::invalid_params(Some(
-                    "Expected an object for the request parameters.".to_owned(),
-                ))
-            });
+            return error_response(request.id, || RpcError::invalid_params(Some(e.to_string())));
         }
     };
 


### PR DESCRIPTION
Instead of always returning `Expected an object for the request parameters` statically to the client when incorrect method parameters are provided, return the `serde_json` error.

Fixes https://github.com/nimiq/core-rs-albatross/issues/3167

Examples:
Input
```
...
"params": [
	"NQ57 M1NT JRQA FGD2 HX1P FN2G 611P JNAE K7HN",
	"",
	-5
]
```
Output
```
...
"error": {
        ...
	"data": "invalid value: integer `-5`, expected u64"
}
...
```
------
Input
```
...
"params": [
	"NQ57 M1NT JRQA FGD2 HX1P FN2G 611P JNAE K7HN",
	"",
],
```
Output
```
...
"error": {
        ...
	"data": "Received invalid JSON"
}
...
```
