### PR TITLE
Fix some clippy warnings

### DIFF
--- a/client/src/wasm_websocket.rs
+++ b/client/src/wasm_websocket.rs
@@ -110,7 +110,7 @@ impl WebsocketClient {
 
         // Register onopen so we can wait for the websocket to be open
         let (ready_tx, ready_rx) = oneshot::channel::<()>();
-        let ready_tx = Arc::new(RefCell::new(Some(ready_tx)));
+        let ready_tx = RefCell::new(Some(ready_tx));
         let onopen_callback = Closure::wrap(Box::new(move |_| {
             if let Some(ready_tx) = ready_tx.replace(None) {
                 ready_tx.send(()).unwrap();

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -346,7 +346,7 @@ impl TryFrom<Value> for SubscriptionId {
             Value::Number(n) => n
                 .as_u64()
                 .map(SubscriptionId::Number)
-                .ok_or_else(|| Error::InvalidSubscriptionId(Value::Number(n))),
+                .ok_or(Error::InvalidSubscriptionId(Value::Number(n))),
             value => Err(Error::InvalidSubscriptionId(value)),
         }
     }


### PR DESCRIPTION
Fix some clippy warnings in the `core` and `client` subcrates.