### PR TITLE
Fix WebSocket stream to send data as JSON text

### DIFF
--- a/client/src/wasm_websocket.rs
+++ b/client/src/wasm_websocket.rs
@@ -62,7 +62,7 @@ pub struct WebsocketClient {
     streams: Arc<RwLock<StreamsMap>>,
     requests: Arc<RwLock<RequestsMap>>,
     next_id: u64,
-    sender: mpsc::Sender<Vec<u8>>,
+    sender: mpsc::Sender<String>,
 }
 
 impl WebsocketClient {
@@ -121,10 +121,10 @@ impl WebsocketClient {
         onopen_callback.forget();
 
         // Spawn future to do the sending for us
-        let (msg_tx, mut msg_rx) = mpsc::channel::<Vec<u8>>(1);
+        let (msg_tx, mut msg_rx) = mpsc::channel::<String>(1);
         wasm_bindgen_futures::spawn_local(async move {
             while let Some(message) = msg_rx.recv().await {
-                ws.send_with_u8_array(&message).unwrap();
+                ws.send_with_str(&message).unwrap();
             }
         });
 
@@ -202,7 +202,7 @@ impl Client for WebsocketClient {
             .expect("Failed to serialize JSON-RPC request.");
 
         self.sender
-            .send(serde_json::to_vec(&request)?)
+            .send(serde_json::to_string(&request)?)
             .await
             .unwrap();
 

--- a/client/src/websocket.rs
+++ b/client/src/websocket.rs
@@ -213,7 +213,7 @@ impl Client for WebsocketClient {
         log::debug!("Sending request: {:?}", request);
 
         self.sender
-            .send(Message::Binary(serde_json::to_vec(&request)?))
+            .send(Message::Text(serde_json::to_string(&request)?))
             .await?;
 
         let (tx, rx) = oneshot::channel();

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -211,9 +211,9 @@ impl<D: Dispatcher> Server<D> {
             .and_then(move |body: Bytes| {
                 let inner = Arc::clone(&inner);
                 async move {
-                    let data = Self::handle_raw_request(inner, &Message::binary(body), None)
+                    let data = Self::handle_raw_request(inner, &Message::text(body), None)
                         .await
-                        .unwrap_or(Message::binary([]));
+                        .unwrap_or(Message::text(""));
 
                     let response = http::response::Builder::new()
                         .status(200)
@@ -352,7 +352,7 @@ impl<D: Dispatcher> Server<D> {
                         .expect("Failed to serialize JSON RPC response"),
                 )
             } else {
-                Message::binary(
+                Message::text(
                     serde_json::to_vec(&response).expect("Failed to serialize JSON RPC response"),
                 )
             }
@@ -700,7 +700,7 @@ where
 
     log::debug!("Sending notification: {:?}", notification);
 
-    tx.send(Message::binary(serde_json::to_vec(&notification)?))
+    tx.send(Message::text(serde_json::to_vec(&notification)?))
         .await?;
 
     Ok(())

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -353,7 +353,7 @@ impl<D: Dispatcher> Server<D> {
                 )
             } else {
                 Message::text(
-                    serde_json::to_vec(&response).expect("Failed to serialize JSON RPC response"),
+                    serde_json::to_string(&response).expect("Failed to serialize JSON RPC response"),
                 )
             }
         })
@@ -700,7 +700,7 @@ where
 
     log::debug!("Sending notification: {:?}", notification);
 
-    tx.send(Message::text(serde_json::to_vec(&notification)?))
+    tx.send(Message::text(serde_json::to_string(&notification)?))
         .await?;
 
     Ok(())


### PR DESCRIPTION
Update WebSocket message handling to use text frames instead of binary frames.

* **client/src/websocket.rs**
  - Update `send_request` method to use `Message::Text` instead of `Message::Binary`.

* **client/src/wasm_websocket.rs**
  - Update `send_request` method to use `ws.send_with_str` instead of `ws.send_with_u8_array`.
  - Change `sender` type from `mpsc::Sender<Vec<u8>>` to `mpsc::Sender<String>`.

* **server/src/lib.rs**
  - Update `handle_raw_request` method to handle text frames using `Message::text`.
  - Change `send` method to use `Message::text` instead of `Message::binary`.
  
Fixes: #3236

