### PR TITLE
Unsubscribe streams

### DIFF
--- a/derive/src/service.rs
+++ b/derive/src/service.rs
@@ -92,7 +92,7 @@ fn impl_service(im: &mut ItemImpl, args: &ServiceMeta) -> TokenStream {
                 request: ::nimiq_jsonrpc_core::Request,
                 tx: Option<&::tokio::sync::mpsc::Sender<::nimiq_jsonrpc_server::Message>>,
                 stream_id: u64,
-            ) -> Option<::nimiq_jsonrpc_core::Response> {
+            ) -> Option<::nimiq_jsonrpc_server::ResponseAndSubScriptionNotifier> {
                 match request.method.as_str() {
                     #(#match_arms)*
                     _ => ::nimiq_jsonrpc_server::method_not_found(request),


### PR DESCRIPTION
By adding a specialised unsubscribe request handler that lets the server terminates specific streams.

This PR is build on top of `stefan/axum` (#36).

Fixes https://github.com/nimiq/core-rs-albatross/issues/3216