### PR TITLE
Option to change how websocket data frames are returned to the client

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -35,6 +35,26 @@ pub enum Error {
     InvalidSubscriptionId(Value),
 }
 
+/// Indicate if a websocket frame response should be in Binary or Text
+#[derive(Copy, Clone, Default)]
+pub enum FrameType {
+    /// Binary frame type
+    #[default]
+    Binary,
+    /// Text frame type
+    Text,
+}
+
+impl From<&String> for FrameType {
+    fn from(value: &String) -> Self {
+        match value.as_str() {
+            "text" => FrameType::Text,
+            "binary" => FrameType::Binary,
+            _ => FrameType::Binary,
+        }
+    }
+}
+
 /// A JSON-RPC request or response can either be a single request or response, or a list of the former. This `enum`
 /// matches either for serialization and deserialization.
 ///

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -152,7 +152,7 @@ impl<'a> RpcMethod<'a> {
                                 let notifier = ::std::sync::Arc::new(::nimiq_jsonrpc_server::Notify::new());
                                 let listener = notifier.clone();
 
-                                let subscription = ::nimiq_jsonrpc_server::connect_stream(stream, tx, stream_id, #method_name.to_owned(), listener);
+                                let subscription = ::nimiq_jsonrpc_server::connect_stream(stream, tx, stream_id, #method_name.to_owned(), listener, frame_type);
 
                                 Ok::<_, ::nimiq_jsonrpc_core::RpcError>((subscription, Some(notifier)))
                             }

--- a/derive/src/service.rs
+++ b/derive/src/service.rs
@@ -92,6 +92,7 @@ fn impl_service(im: &mut ItemImpl, args: &ServiceMeta) -> TokenStream {
                 request: ::nimiq_jsonrpc_core::Request,
                 tx: Option<&::tokio::sync::mpsc::Sender<::nimiq_jsonrpc_server::Message>>,
                 stream_id: u64,
+                frame_type: Option<::nimiq_jsonrpc_core::FrameType>,
             ) -> Option<::nimiq_jsonrpc_server::ResponseAndSubScriptionNotifier> {
                 match request.method.as_str() {
                     #(#match_arms)*


### PR DESCRIPTION
The websocket specification defines 2 ways how application-layer data transmitted over the socket can be represented: `Text` or `Binary`. Currently the default data frame representation returned by the RPC server is `Binary` but this is counterintuitive since JSONRPC already is in a text representation.

This PR let the client, per connection, decide in which representation data should be returned by the server. This is achived by adding support for a `frame` query parameter on the `/ws` endpoint. Examples:
- ws://127.0.0.1:8000/ws		--> data frames are returned as `Binary` (default)
- ws://127.0.0.1:8000/ws?frame=text	--> data frames are returned as `Text`
- ws://127.0.0.1:8000/ws?frame=binary	--> data frames are returned as `Binary`
- ws://127.0.0.1:8000/ws?frame=foo   	--> data frames are returned as `Binary` (Fallback for unsupported values)

To accomplish backwards compatibility `Binary` is still the default returned representation but in a major release this should be changed to `Text`