### PR TITLE
Remove `mut` requirement from methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ use nimiq_jsonrpc_client::http::HttpClient;
 #[nimiq_jsonrpc_derive::proxy]
 #[async_trait]
 trait Foobar {
-    async fn hello(&mut self, name: String) -> String;
+    async fn hello(&self, name: String) -> String;
 }
 
 struct FoobarService;
@@ -28,7 +28,7 @@ struct FoobarService;
 #[nimiq_jsonrpc_derive::service]
 #[async_trait]
 impl Foobar for FoobarService {
-    async fn hello(&mut self, name: String) -> String {
+    async fn hello(&self, name: String) -> String {
         println!("Hello, {}", name);
         format!("Hello, {}", name)
     }

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,7 +11,7 @@
 //! #[async_trait]
 //! trait Foobar {
 //!     type Error;
-//!     async fn hello(&mut self, name: String) -> Result<String, Self::Error>;
+//!     async fn hello(&self, name: String) -> Result<String, Self::Error>;
 //! }
 //!```
 //!

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -215,7 +215,7 @@ impl<'a> RpcMethod<'a> {
         };
 
         quote! {
-            async fn #method_ident(&mut self, #(#method_args),*) #output {
+            async fn #method_ident(&self, #(#method_args),*) #output {
                 let args = #args_struct_ident {
                     #(#struct_fields),*
                 };

--- a/examples/basic_auth/src/main.rs
+++ b/examples/basic_auth/src/main.rs
@@ -25,7 +25,7 @@ struct HelloWorldData {
 trait HelloWorld {
     type Error;
 
-    async fn hello(&mut self, name: String, x: HelloWorldData) -> Result<String, Self::Error>;
+    async fn hello(&self, name: String, x: HelloWorldData) -> Result<String, Self::Error>;
 }
 
 /// Define a service that implements our `HelloWorld` RPC interface.
@@ -45,7 +45,7 @@ impl HelloWorld for HelloWorldService {
     type Error = ();
 
     /// Here we implement a method that then can be called from a remote client.
-    async fn hello(&mut self, name: String, x: HelloWorldData) -> Result<String, Self::Error> {
+    async fn hello(&self, name: String, x: HelloWorldData) -> Result<String, Self::Error> {
         Ok(format!("Hello, {}: x={:?}", name, x))
     }
 }
@@ -87,7 +87,7 @@ async fn main() {
         "http://localhost:8000/".parse().unwrap(),
         Some(credentials.clone()),
     );
-    let mut proxy = HelloWorldProxy::new(client);
+    let proxy = HelloWorldProxy::new(client);
     let retval = proxy
         .hello("World".to_owned(), HelloWorldData { a: 42 })
         .await
@@ -98,7 +98,7 @@ async fn main() {
     let client = WebsocketClient::new("ws://localhost:8000/ws".parse().unwrap(), Some(credentials))
         .await
         .unwrap();
-    let mut proxy = HelloWorldProxy::new(client);
+    let proxy = HelloWorldProxy::new(client);
     let retval = proxy
         .hello("World".to_owned(), HelloWorldData { a: 42 })
         .await

--- a/examples/hello_world/src/main.rs
+++ b/examples/hello_world/src/main.rs
@@ -23,7 +23,7 @@ struct HelloWorldData {
 trait HelloWorld {
     type Error;
 
-    async fn hello(&mut self, name: String, x: HelloWorldData) -> Result<String, Self::Error>;
+    async fn hello(&self, name: String, x: HelloWorldData) -> Result<String, Self::Error>;
 }
 
 /// Define a service that implements our `HelloWorld` RPC interface.
@@ -43,7 +43,7 @@ impl HelloWorld for HelloWorldService {
     type Error = ();
 
     /// Here we implement a method that then can be called from a remote client.
-    async fn hello(&mut self, name: String, x: HelloWorldData) -> Result<String, Self::Error> {
+    async fn hello(&self, name: String, x: HelloWorldData) -> Result<String, Self::Error> {
         Ok(format!("Hello, {}: x={:?}", name, x))
     }
 }
@@ -82,7 +82,7 @@ async fn main() {
     let client = HttpClient::with_url("http://localhost:8000/".parse().unwrap());
 
     // Next we can use the proxy that we generated earlier and construct it with the client.
-    let mut proxy = HelloWorldProxy::new(client);
+    let proxy = HelloWorldProxy::new(client);
 
     // The proxy implements our `HelloWorld` RPC interface and will send a request to the server, when a method is
     // called.

--- a/examples/pubsub/src/main.rs
+++ b/examples/pubsub/src/main.rs
@@ -14,7 +14,7 @@ trait HelloWorld {
     type Error;
 
     #[stream]
-    async fn hello_subscribe(&mut self) -> Result<BoxStream<'static, String>, Self::Error>;
+    async fn hello_subscribe(&self) -> Result<BoxStream<'static, String>, Self::Error>;
 }
 
 struct HelloWorldService;
@@ -25,7 +25,7 @@ impl HelloWorld for HelloWorldService {
     type Error = ();
 
     #[stream]
-    async fn hello_subscribe(&mut self) -> Result<BoxStream<'static, String>, Self::Error> {
+    async fn hello_subscribe(&self) -> Result<BoxStream<'static, String>, Self::Error> {
         log::info!("Client subscribed");
 
         let mut interval = tokio::time::interval(Duration::from_secs(1));
@@ -63,7 +63,7 @@ async fn main() {
 
     let url = "ws://localhost:8000/ws".parse().unwrap();
     let client = WebsocketClient::with_url(url).await.unwrap();
-    let mut proxy = HelloWorldProxy::new(client);
+    let proxy = HelloWorldProxy::new(client);
 
     let mut stream = proxy.hello_subscribe().await.unwrap();
 


### PR DESCRIPTION
- Remove the `mut` requirement from the client methods by using internal mutability and atomic counters.
- Now that the RPC methods don't require the client to have `&mut self`, change the derive macros to produce methods that don't have it.