### PR TITLE
client: Add TLS support to `tokio-tungstenite`

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1.43", features = ["net", "sync"], optional = true }
-tokio-tungstenite = { version = "0.26", optional = true }
+tokio-tungstenite = { version = "0.26", optional = true, features =  ["native-tls"] }
 url = "2.3"
 wasm-bindgen = { version = "0.2", optional = true }
 wasm-bindgen-futures = { version = "0.4", optional = true }


### PR DESCRIPTION
Add TLS support to `tokio-tungstenite` such that the client can initiate web socket secure connections.