### PR TITLE
Apply `rename_all` casing to RPC parameter names including a compat shim

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -5,7 +5,7 @@ use darling::FromMeta;
 use heck::{ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
-use syn::{Attribute, FnArg, Ident, Pat, Signature, Type};
+use syn::{spanned::Spanned, Attribute, FnArg, Ident, Pat, Signature, Type};
 
 use proxy::proxy_macro;
 use service::service_macro;
@@ -51,7 +51,7 @@ impl MethodAttributes {
 
 pub(crate) struct RpcMethod<'a> {
     signature: &'a Signature,
-    args: Vec<(&'a Ident, &'a Type)>,
+    args: Vec<(Ident, &'a Type)>,
     method_name: String,
     method_name_literal: Literal,
     args_struct_ident: Ident,
@@ -67,6 +67,7 @@ impl<'a> RpcMethod<'a> {
     ) -> Self {
         let mut has_self = false;
         let mut args = vec![];
+        let rename_all = rename_all.as_ref();
 
         for arg in &signature.inputs {
             match arg {
@@ -75,7 +76,10 @@ impl<'a> RpcMethod<'a> {
                 }
                 FnArg::Typed(pat_type) => {
                     let ident = match &*pat_type.pat {
-                        Pat::Ident(ty) => &ty.ident,
+                        Pat::Ident(ty) => {
+                            let name = RenameAll::rename_or(rename_all, ty.ident.to_string());
+                            Ident::new(&name, ty.span())
+                        }
                         _ => panic!("Arguments must not be patterns."),
                     };
                     args.push((ident, &*pat_type.ty));
@@ -90,11 +94,7 @@ impl<'a> RpcMethod<'a> {
         let attrs = MethodAttributes::parse(attrs);
         //println!("Method attributes: {:?}", attrs);
 
-        let method_name = signature.ident.to_string();
-        let method_name = rename_all
-            .as_ref()
-            .map(|r| r.rename(&method_name))
-            .unwrap_or(method_name);
+        let method_name = RenameAll::rename_or(rename_all, signature.ident.to_string());
         let method_name_literal = Literal::string(&method_name);
 
         let args_struct_ident = format_ident!("{}_{}", args_struct_prefix, signature.ident);
@@ -120,6 +120,7 @@ impl<'a> RpcMethod<'a> {
         let tokens = quote! {
             #[derive(Debug, ::serde::Serialize, ::serde::Deserialize)]
             #[allow(non_camel_case_types)]
+            #[allow(non_snake_case)]
             struct #args_struct_ident {
                 #(#struct_fields)*
             }
@@ -215,6 +216,7 @@ impl<'a> RpcMethod<'a> {
         };
 
         quote! {
+            #[allow(non_snake_case)]
             async fn #method_ident(&self, #(#method_args),*) #output {
                 let args = #args_struct_ident {
                     #(#struct_fields),*
@@ -257,6 +259,14 @@ impl FromStr for RenameAll {
 }
 
 impl RenameAll {
+    /// Applies `rename_all` to `name` when present, otherwise returns `name` unchanged.
+    pub fn rename_or(rename_all: Option<&RenameAll>, name: String) -> String {
+        match rename_all {
+            Some(r) => r.rename(&name),
+            None => name,
+        }
+    }
+
     pub fn rename(&self, name: &str) -> String {
         match self {
             RenameAll::Camel => name.to_upper_camel_case(),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -5,7 +5,7 @@ use darling::FromMeta;
 use heck::{ToKebabCase, ToLowerCamelCase, ToShoutySnakeCase, ToSnakeCase, ToUpperCamelCase};
 use proc_macro2::{Literal, TokenStream};
 use quote::{format_ident, quote};
-use syn::{spanned::Spanned, Attribute, FnArg, Ident, Pat, Signature, Type};
+use syn::{Attribute, FnArg, Ident, Pat, Signature, Type};
 
 use proxy::proxy_macro;
 use service::service_macro;
@@ -49,9 +49,24 @@ impl MethodAttributes {
     }
 }
 
+/// A single RPC method argument.
+///
+/// The Rust field/parameter name is always the original `snake_case` `ident`.
+/// When `rename_all` produces a *different* wire name, it is stored in `rename`
+/// and emitted as a `#[serde(rename = "<new>", alias = "<original>")]` attribute
+/// on the generated args struct — so the new name is sent on the wire while the
+/// original name is still accepted on deserialization (a backward-compatible
+/// transition shim). `rename` is `None` when no `rename_all` is configured, or
+/// when it maps the name to itself.
+struct RpcArg<'a> {
+    ident: Ident,
+    rename: Option<String>,
+    ty: &'a Type,
+}
+
 pub(crate) struct RpcMethod<'a> {
     signature: &'a Signature,
-    args: Vec<(Ident, &'a Type)>,
+    args: Vec<RpcArg<'a>>,
     method_name: String,
     method_name_literal: Literal,
     args_struct_ident: Ident,
@@ -76,13 +91,19 @@ impl<'a> RpcMethod<'a> {
                 }
                 FnArg::Typed(pat_type) => {
                     let ident = match &*pat_type.pat {
-                        Pat::Ident(ty) => {
-                            let name = RenameAll::rename_or(rename_all, ty.ident.to_string());
-                            Ident::new(&name, ty.span())
-                        }
+                        Pat::Ident(ty) => ty.ident.clone(),
                         _ => panic!("Arguments must not be patterns."),
                     };
-                    args.push((ident, &*pat_type.ty));
+                    // Keep the original `snake_case` identifier as the Rust field name;
+                    // only record a wire rename when `rename_all` actually changes it.
+                    let original = ident.to_string();
+                    let renamed = RenameAll::rename_or(rename_all, original.clone());
+                    let rename = (renamed != original).then_some(renamed);
+                    args.push(RpcArg {
+                        ident,
+                        rename,
+                        ty: &pat_type.ty,
+                    });
                 }
             }
         }
@@ -113,14 +134,25 @@ impl<'a> RpcMethod<'a> {
         let struct_fields = self
             .args
             .iter()
-            .map(|(ident, ty)| quote! { #ident: #ty, })
+            .map(|arg| {
+                let RpcArg { ident, rename, ty } = arg;
+                // When `rename_all` changed the name, send the new name on the wire
+                // (`rename`) but still accept the original name (`alias`).
+                let serde_attr = match rename {
+                    Some(new) => {
+                        let old = ident.to_string();
+                        quote! { #[serde(rename = #new, alias = #old)] }
+                    }
+                    None => quote! {},
+                };
+                quote! { #serde_attr #ident: #ty, }
+            })
             .collect::<Vec<TokenStream>>();
         let args_struct_ident = &self.args_struct_ident;
 
         let tokens = quote! {
             #[derive(Debug, ::serde::Serialize, ::serde::Deserialize)]
             #[allow(non_camel_case_types)]
-            #[allow(non_snake_case)]
             struct #args_struct_ident {
                 #(#struct_fields)*
             }
@@ -135,7 +167,10 @@ impl<'a> RpcMethod<'a> {
         let method_args = self
             .args
             .iter()
-            .map(|(ident, _)| quote! { params.#ident })
+            .map(|arg| {
+                let ident = &arg.ident;
+                quote! { params.#ident }
+            })
             .collect::<Vec<TokenStream>>();
         let args_struct_ident = &self.args_struct_ident;
         let method_ident = &self.signature.ident;
@@ -198,13 +233,19 @@ impl<'a> RpcMethod<'a> {
         let method_args = self
             .args
             .iter()
-            .map(|(ident, ty)| quote! { #ident: #ty })
+            .map(|arg| {
+                let (ident, ty) = (&arg.ident, arg.ty);
+                quote! { #ident: #ty }
+            })
             .collect::<Vec<TokenStream>>();
 
         let struct_fields = self
             .args
             .iter()
-            .map(|(ident, _)| quote! { #ident })
+            .map(|arg| {
+                let ident = &arg.ident;
+                quote! { #ident }
+            })
             .collect::<Vec<TokenStream>>();
 
         let transform_return_value = if self.attrs.stream.is_some() {
@@ -216,7 +257,6 @@ impl<'a> RpcMethod<'a> {
         };
 
         quote! {
-            #[allow(non_snake_case)]
             async fn #method_ident(&self, #(#method_args),*) #output {
                 let args = #args_struct_ident {
                     #(#struct_fields),*

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -177,9 +177,31 @@ impl<'a> RpcMethod<'a> {
         let method_name = &self.method_name;
         let method_name_literal = &self.method_name_literal;
 
+        // Warn (once per call) if a client still sends a renamed parameter under its
+        // original (legacy) name, which is accepted via a serde `alias`. Emitted only
+        // when at least one parameter was actually renamed.
+        let legacy_param_names = self
+            .args
+            .iter()
+            .filter(|arg| arg.rename.is_some())
+            .map(|arg| arg.ident.to_string())
+            .collect::<Vec<String>>();
+        let warn_legacy_params = if legacy_param_names.is_empty() {
+            quote! {}
+        } else {
+            quote! {
+                ::nimiq_jsonrpc_server::warn_on_legacy_param_names(
+                    &request.params,
+                    #method_name_literal,
+                    &[#(#legacy_param_names),*],
+                );
+            }
+        };
+
         if self.attrs.stream.is_some() {
             quote! {
                 #method_name_literal => {
+                    #warn_legacy_params
                     if let Some(tx) = tx {
                         return ::nimiq_jsonrpc_server::dispatch_method_with_args(
                             request,
@@ -206,6 +228,7 @@ impl<'a> RpcMethod<'a> {
         } else {
             quote! {
                 #method_name_literal => {
+                    #warn_legacy_params
                     return ::nimiq_jsonrpc_server::dispatch_method_with_args(
                         request,
                         move |params: #args_struct_ident| async move {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -771,6 +771,34 @@ where
     response(request.id, result)
 }
 
+/// Emits a deprecation warning if the request supplies any parameter under its
+/// pre-`rename_all` name.
+///
+/// When a service is annotated with `rename_all`, the renamed parameters are
+/// still accepted under their original (legacy) names via a serde `alias`, to
+/// give clients time to migrate. This helper lets operators observe whether any
+/// client is still relying on that shim. It is a no-op unless a legacy name is
+/// actually present in the request.
+///
+/// This is a helper function used by implementations of `Dispatcher`.
+pub fn warn_on_legacy_param_names(
+    params: &Option<Value>,
+    method: &str,
+    legacy_param_names: &[&str],
+) {
+    if let Some(Value::Object(obj)) = params {
+        if legacy_param_names
+            .iter()
+            .any(|name| obj.contains_key(*name))
+        {
+            log::warn!(
+                "RPC call to '{}' used a deprecated parameter name; update the client to the renamed parameters",
+                method
+            );
+        }
+    }
+}
+
 /// Read the request and call a handler function if possible. This variant accepts calls without arguments.
 ///
 /// This is a helper function used by implementations of `Dispatcher`.

--- a/server/tests/legacy_param_warning.rs
+++ b/server/tests/legacy_param_warning.rs
@@ -1,0 +1,131 @@
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use log::{Level, Metadata, Record};
+use serde_json::{json, Value};
+
+use nimiq_jsonrpc_core::Request;
+use nimiq_jsonrpc_server::Dispatcher;
+
+// ---- minimal capturing logger ------------------------------------------------
+
+static WARNINGS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+struct CaptureLogger;
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= Level::Warn
+    }
+
+    fn log(&self, record: &Record) {
+        if record.level() == Level::Warn {
+            WARNINGS.lock().unwrap().push(record.args().to_string());
+        }
+    }
+
+    fn flush(&self) {}
+}
+
+static LOGGER: CaptureLogger = CaptureLogger;
+
+fn install_logger() {
+    // `set_logger` only succeeds once per process; ignore the error on the
+    // second-and-later calls so every test can call this freely.
+    let _ = log::set_logger(&LOGGER);
+    log::set_max_level(log::LevelFilter::Warn);
+}
+
+fn drain_warnings() -> Vec<String> {
+    std::mem::take(&mut *WARNINGS.lock().unwrap())
+}
+
+// ---- service under test ------------------------------------------------------
+
+#[async_trait]
+trait Calculator {
+    type Error;
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error>;
+}
+
+struct CalculatorService;
+
+#[nimiq_jsonrpc_derive::service(rename_all = "camelCase")]
+#[async_trait]
+impl Calculator for CalculatorService {
+    type Error = ();
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error> {
+        Ok(first_operand + second_operand)
+    }
+}
+
+async fn dispatch(method: &str, params: Value) -> nimiq_jsonrpc_core::Response {
+    let mut service = CalculatorService;
+    let request = Request::new(method.to_owned(), Some(params), Some(json!(1)));
+    let (response, _) = service
+        .dispatch(request, None, 0, None)
+        .await
+        .expect("expected a response for a request carrying an id");
+    response
+}
+
+// The capture logger is process-global, so these cases must not run
+// concurrently. Drive them from a single `#[tokio::test]` and drain between
+// steps rather than relying on per-test isolation.
+#[tokio::test]
+async fn legacy_param_name_emits_a_single_warning() {
+    install_logger();
+
+    // New name: must NOT warn.
+    let _ = drain_warnings();
+    let response = dispatch(
+        "addNumbers",
+        json!({ "firstOperand": 2, "secondOperand": 3 }),
+    )
+    .await;
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(response.result, Some(json!(5)));
+    assert!(
+        drain_warnings().is_empty(),
+        "the renamed (current) parameter names must not trigger a deprecation warning"
+    );
+
+    // Legacy (aliased) name: must warn exactly once, and still succeed.
+    let response = dispatch(
+        "addNumbers",
+        json!({ "first_operand": 2, "second_operand": 3 }),
+    )
+    .await;
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(response.result, Some(json!(5)));
+    let warnings = drain_warnings();
+    assert_eq!(
+        warnings.len(),
+        1,
+        "expected exactly one deprecation warning, got: {warnings:?}"
+    );
+    assert!(
+        warnings[0].contains("addNumbers") && warnings[0].contains("deprecated"),
+        "warning should name the method and mention deprecation, got: {}",
+        warnings[0]
+    );
+
+    // A single legacy name among otherwise-current names still warns once.
+    let response = dispatch(
+        "addNumbers",
+        json!({ "first_operand": 2, "secondOperand": 3 }),
+    )
+    .await;
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(drain_warnings().len(), 1);
+}

--- a/server/tests/rename_params.rs
+++ b/server/tests/rename_params.rs
@@ -1,0 +1,215 @@
+use async_trait::async_trait;
+use serde_json::{json, Value};
+
+use nimiq_jsonrpc_core::Request;
+use nimiq_jsonrpc_server::Dispatcher;
+
+#[async_trait]
+trait Calculator {
+    type Error;
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error>;
+}
+
+struct CalculatorService;
+
+#[nimiq_jsonrpc_derive::service(rename_all = "camelCase")]
+#[async_trait]
+impl Calculator for CalculatorService {
+    type Error = ();
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error> {
+        Ok(first_operand + second_operand)
+    }
+}
+
+/// Dispatches a request to `CalculatorService` and returns the JSON response
+/// (always requesting an `id` so a response is produced).
+async fn dispatch(method: &str, params: Value) -> nimiq_jsonrpc_core::Response {
+    let mut service = CalculatorService;
+    let request = Request::new(method.to_owned(), Some(params), Some(json!(1)));
+    let (response, _) = service
+        .dispatch(request, None, 0, None)
+        .await
+        .expect("expected a response for a request carrying an id");
+    response
+}
+
+#[tokio::test]
+async fn method_name_is_renamed_to_camel_case() {
+    // `add_numbers` -> `addNumbers`; the original snake_case name is gone.
+    assert!(CalculatorService.match_method("addNumbers"));
+    assert!(!CalculatorService.match_method("add_numbers"));
+}
+
+#[tokio::test]
+async fn camel_case_param_names_are_accepted_on_the_wire() {
+    let response = dispatch(
+        "addNumbers",
+        json!({ "firstOperand": 2, "secondOperand": 3 }),
+    )
+    .await;
+
+    assert!(
+        response.error.is_none(),
+        "camelCase params should deserialize, got error: {:?}",
+        response.error
+    );
+    assert_eq!(response.result, Some(json!(5)));
+}
+
+#[tokio::test]
+async fn original_snake_case_param_names_are_still_accepted() {
+    // The original snake_case names survive as a serde `alias`, so the
+    // pre-rename wire spelling still deserializes. This is the transition shim
+    // that keeps existing clients working after a service adopts `rename_all`.
+    let response = dispatch(
+        "addNumbers",
+        json!({ "first_operand": 2, "second_operand": 3 }),
+    )
+    .await;
+
+    assert!(
+        response.error.is_none(),
+        "snake_case aliases should still deserialize, got error: {:?}",
+        response.error
+    );
+    assert_eq!(response.result, Some(json!(5)));
+}
+
+#[tokio::test]
+async fn sending_both_spellings_is_rejected_as_duplicate() {
+    // Supplying a field under both its rename and its alias is a duplicate, not
+    // a silent merge.
+    let response = dispatch(
+        "addNumbers",
+        json!({ "firstOperand": 2, "first_operand": 2, "secondOperand": 3 }),
+    )
+    .await;
+
+    let error = response
+        .error
+        .expect("supplying a field under both its rename and its alias is invalid");
+    // -32602 == invalid params per the JSON-RPC spec.
+    assert_eq!(error.code, -32602);
+}
+
+#[async_trait]
+trait KebabCalculator {
+    type Error;
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error>;
+}
+
+struct KebabService;
+
+#[nimiq_jsonrpc_derive::service(rename_all = "kebab-case")]
+#[async_trait]
+impl KebabCalculator for KebabService {
+    type Error = ();
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error> {
+        Ok(first_operand + second_operand)
+    }
+}
+
+async fn dispatch_kebab(method: &str, params: Value) -> nimiq_jsonrpc_core::Response {
+    let mut service = KebabService;
+    let request = Request::new(method.to_owned(), Some(params), Some(json!(1)));
+    let (response, _) = service
+        .dispatch(request, None, 0, None)
+        .await
+        .expect("expected a response for a request carrying an id");
+    response
+}
+
+#[tokio::test]
+async fn kebab_case_compiles_and_accepts_both_spellings() {
+    // `add_numbers` -> `add-numbers`.
+    assert!(KebabService.match_method("add-numbers"));
+
+    // The kebab wire name.
+    let renamed = dispatch_kebab(
+        "add-numbers",
+        json!({ "first-operand": 2, "second-operand": 3 }),
+    )
+    .await;
+    assert!(
+        renamed.error.is_none(),
+        "kebab params should deserialize, got error: {:?}",
+        renamed.error
+    );
+    assert_eq!(renamed.result, Some(json!(5)));
+
+    // The original snake_case alias.
+    let aliased = dispatch_kebab(
+        "add-numbers",
+        json!({ "first_operand": 2, "second_operand": 3 }),
+    )
+    .await;
+    assert!(
+        aliased.error.is_none(),
+        "snake_case alias should still deserialize, got error: {:?}",
+        aliased.error
+    );
+    assert_eq!(aliased.result, Some(json!(5)));
+}
+
+// A `snake_case` service: every name maps to itself, so no `rename`/`alias`
+// attribute is emitted at all (the `new == old` no-op branch). The field name
+// stays the plain original, and only that spelling is accepted.
+#[async_trait]
+trait SnakeCalculator {
+    type Error;
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error>;
+}
+
+struct SnakeService;
+
+#[nimiq_jsonrpc_derive::service(rename_all = "snake_case")]
+#[async_trait]
+impl SnakeCalculator for SnakeService {
+    type Error = ();
+
+    async fn add_numbers(
+        &self,
+        first_operand: u32,
+        second_operand: u32,
+    ) -> Result<u32, Self::Error> {
+        Ok(first_operand + second_operand)
+    }
+}
+
+#[tokio::test]
+async fn snake_case_identity_emits_no_alias() {
+    let mut service = SnakeService;
+    let request = Request::new(
+        "add_numbers".to_owned(),
+        Some(json!({ "first_operand": 2, "second_operand": 3 })),
+        Some(json!(1)),
+    );
+    let (response, _) = service.dispatch(request, None, 0, None).await.unwrap();
+    assert!(response.error.is_none(), "{:?}", response.error);
+    assert_eq!(response.result, Some(json!(5)));
+}


### PR DESCRIPTION
Extend `#[service(rename_all = …)]` and `#[proxy(rename_all = …)]` to rename RPC parameter names on the JSON wire including an automatic alias in order to retain backwards compatibility.

This PR supersedes #30 as it's non-breaking.

The three commits:

- Rename method parameters to the configured casing — params now follow the same `rename_all` convention as method names (e.g. `first_operand` → `firstOperand`).
- Generate a `serde` alias for backward compatibility — instead of renaming the Rust identifier, the macro keeps idents `snake_case` and emits `#[serde(rename = "<new>", alias = "<old>")]` per field. Servers therefore will accept both the new and the original name during the migration window. This also fixes a compile-time panic for `rename_all = "kebab-case"` (a hyphen is not a valid Rust identifier).
- Warning at runtime when a legacy parameter name is used — the dispatcher emits a single `log::warn!` per request when a request still uses a pre-rename parameter name. Is a no-op when no params were renamed.

### Examples

Old style still being accepted when `rename_all` is set to `camelCase` because of the alias for compatibility. Note: in this case a `log::warn` is outputted on the server side since at least one parameter isn't in camel case.
```
{
	"jsonrpc": "2.0",
	"method": "addNumbers",
	"params": {
		"first_operand": 2,
		"second_operand": 3
	},
	"id": 1
}
```

New style is also supported when `rename_all` is set to `camelCase`
```
{
	"jsonrpc": "2.0",
	"method": "addNumbers",
	"params": {
		"firstOperand": 2,
		"secondOperand": 3
	},
	"id": 1
}
```