### PR TITLE
client: Use native-tls for reqwest instead of the default rustls

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -19,7 +19,11 @@ futures = "0.3"
 http = { version = "1.2", optional = true }
 js-sys = { version = "0.3", optional = true }
 log = "0.4"
-reqwest = { version = "0.13", optional = true, features = ["json"] }
+reqwest = { version = "0.13", optional = true, default-features = false, features = [
+  "json",
+  "native-tls",
+  "system-proxy",
+] }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = "2.0"


### PR DESCRIPTION
reqwest 0.13 switched its `default-tls` to rustls with the aws-lc-rs provider, which conflicts with a ring-backed rustls downstream and makes rustls unable to pick a process-level `CryptoProvider`. Select `native-tls` explicitly, as we already do for tokio-tungstenite, and enable only the other reqwest features we need.