### PR TITLE
client: Detect blackholed websocket connections with a heartbeat

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -50,6 +50,7 @@ features = [
 
 [dev-dependencies]
 nimiq-jsonrpc-derive = { workspace = true }
+tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "time"] }
 
 [features]
 default = ["http-client", "websocket-client"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -56,4 +56,4 @@ tokio = { version = "1.43", features = ["macros", "rt-multi-thread", "time"] }
 default = ["http-client", "websocket-client"]
 http-client = ["reqwest"]
 wasm-websocket-client = ["js-sys", "tokio", "wasm-bindgen", "wasm-bindgen-futures", "web-sys"]
-websocket-client = ["base64", "http", "tokio", "tokio/net", "tokio/rt", "tokio-tungstenite"]
+websocket-client = ["base64", "http", "tokio", "tokio/net", "tokio/rt", "tokio/time", "tokio-tungstenite"]

--- a/client/src/websocket.rs
+++ b/client/src/websocket.rs
@@ -4,8 +4,9 @@ use std::{
     str::FromStr,
     sync::{
         atomic::{AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex,
     },
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -20,6 +21,7 @@ use thiserror::Error;
 use tokio::{
     net::TcpStream,
     sync::{mpsc, oneshot, watch, RwLock},
+    time::MissedTickBehavior,
 };
 use tokio_tungstenite::tungstenite::{
     client::IntoClientRequest,
@@ -68,6 +70,30 @@ pub enum Error {
     ConnectionClosed,
 }
 
+/// Configuration for a [`WebsocketClient`].
+#[derive(Clone, Debug)]
+pub struct Config {
+    /// How often to send a websocket ping. `None` disables the heartbeat entirely.
+    ///
+    /// The heartbeat exists to notice connections that are silently blackholed - typically by a
+    /// firewall or a load balancer dropping an idle flow - which produce neither an error nor an
+    /// EOF and would otherwise never be detected.
+    pub ping_interval: Option<Duration>,
+
+    /// Consider the connection dead once nothing has been received for this long. Should be a
+    /// multiple of `ping_interval`, so that a single lost ping doesn't drop the connection.
+    pub ping_timeout: Duration,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            ping_interval: Some(Duration::from_secs(15)),
+            ping_timeout: Duration::from_secs(45),
+        }
+    }
+}
+
 type StreamsMap = HashMap<SubscriptionId, mpsc::Sender<SubscriptionMessage<Value>>>;
 type RequestsMap = HashMap<u64, oneshot::Sender<Response>>;
 
@@ -76,7 +102,7 @@ type RequestsMap = HashMap<u64, oneshot::Sender<Response>>;
 pub struct WebsocketClient {
     streams: Arc<RwLock<StreamsMap>>,
     requests: Arc<RwLock<RequestsMap>>,
-    sender: RwLock<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>,
+    sender: Arc<RwLock<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>>,
     closed: Arc<watch::Sender<bool>>,
     next_id: AtomicU64,
 }
@@ -90,6 +116,22 @@ impl WebsocketClient {
     ///  - `basic_auth`: Credentials for HTTP basic auth.
     ///
     pub async fn new(url: Url, basic_auth: Option<Credentials>) -> Result<Self, Error> {
+        Self::new_with_config(url, basic_auth, Config::default()).await
+    }
+
+    /// Creates a new JSON-RPC websocket client with a custom configuration.
+    ///
+    /// # Arguments
+    ///
+    ///  - `url`: The URL of the websocket endpoint (.e.g `ws://localhost:8000/ws`)
+    ///  - `basic_auth`: Credentials for HTTP basic auth.
+    ///  - `config`: Heartbeat configuration, see [`Config`].
+    ///
+    pub async fn new_with_config(
+        url: Url,
+        basic_auth: Option<Credentials>,
+        config: Config,
+    ) -> Result<Self, Error> {
         let request = {
             let uri: http::Uri = url.to_string().parse().unwrap();
             let mut request = uri.into_client_request()?;
@@ -120,16 +162,24 @@ impl WebsocketClient {
         let streams = Arc::new(RwLock::new(HashMap::new()));
         let requests = Arc::new(RwLock::new(HashMap::new()));
         let closed = Arc::new(watch::channel(false).0);
+        let sender = Arc::new(RwLock::new(ws_tx));
+
+        // When the last message was received, used by the heartbeat to tell a live connection
+        // from a blackholed one.
+        let last_seen = Arc::new(Mutex::new(Instant::now()));
 
         {
             let streams = Arc::clone(&streams);
             let requests = Arc::clone(&requests);
             let closed = Arc::clone(&closed);
+            let last_seen = Arc::clone(&last_seen);
 
             tokio::spawn(async move {
                 while let Some(message_result) = ws_rx.next().await {
                     match message_result {
                         Ok(message) => {
+                            *last_seen.lock().unwrap() = Instant::now();
+
                             if let Err(e) =
                                 Self::handle_websocket_message(&streams, &requests, message).await
                             {
@@ -149,13 +199,75 @@ impl WebsocketClient {
             });
         }
 
+        if let Some(interval) = config.ping_interval {
+            Self::spawn_heartbeat(
+                Arc::clone(&sender),
+                Arc::clone(&streams),
+                Arc::clone(&requests),
+                Arc::clone(&closed),
+                last_seen,
+                interval,
+                config.ping_timeout,
+            );
+        }
+
         Ok(Self {
             next_id: AtomicU64::new(1),
-            sender: RwLock::new(ws_tx),
+            sender,
             streams,
             requests,
             closed,
         })
+    }
+
+    /// Sends a websocket ping every `interval`, and tears the connection down once nothing has
+    /// been received for `timeout`.
+    ///
+    /// A silently blackholed connection produces neither an error nor an EOF, so the reader task
+    /// waits on it forever and never gets to tear it down. Pings going unanswered is the only
+    /// symptom there is.
+    fn spawn_heartbeat(
+        sender: Arc<RwLock<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>>,
+        streams: Arc<RwLock<StreamsMap>>,
+        requests: Arc<RwLock<RequestsMap>>,
+        closed: Arc<watch::Sender<bool>>,
+        last_seen: Arc<Mutex<Instant>>,
+        interval: Duration,
+        timeout: Duration,
+    ) {
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+            let mut is_closed = closed.subscribe();
+
+            loop {
+                tokio::select! {
+                    _ = ticker.tick() => {}
+                    // Stop as soon as the connection is torn down, so the task doesn't outlive
+                    // it and keep the sink alive.
+                    _ = is_closed.wait_for(|closed| *closed) => break,
+                }
+
+                let idle = last_seen.lock().unwrap().elapsed();
+                if idle > timeout {
+                    log::error!("Nothing received for {:?}, closing the connection", idle);
+                    Self::teardown(&streams, &requests, &closed).await;
+                    break;
+                }
+
+                if let Err(e) = sender
+                    .write()
+                    .await
+                    .send(Message::Ping(Default::default()))
+                    .await
+                {
+                    // Don't tear down here - either the read side reports the death, or the
+                    // idle check above does.
+                    log::error!("Failed to send ping: {}", e);
+                }
+            }
+        });
     }
 
     /// Creates a new JSON-RPC websocket client.

--- a/client/src/websocket.rs
+++ b/client/src/websocket.rs
@@ -213,7 +213,15 @@ impl WebsocketClient {
         requests: &Arc<RwLock<RequestsMap>>,
         message: Message,
     ) -> Result<(), Error> {
-        // FIXME: This will also accept pings
+        // Control frames are answered by the protocol implementation itself and carry no JSON-RPC
+        // payload, so they must not be parsed as one.
+        if matches!(
+            message,
+            Message::Ping(_) | Message::Pong(_) | Message::Close(_)
+        ) {
+            return Ok(());
+        }
+
         let data = message.into_text()?;
 
         log::trace!("Received message: {:?}", data);

--- a/client/src/websocket.rs
+++ b/client/src/websocket.rs
@@ -12,14 +12,14 @@ use async_trait::async_trait;
 use base64::Engine;
 use futures::{
     sink::SinkExt,
-    stream::{BoxStream, SplitSink, StreamExt},
+    stream::{self, BoxStream, SplitSink, StreamExt},
 };
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
 use tokio::{
     net::TcpStream,
-    sync::{mpsc, oneshot, RwLock},
+    sync::{mpsc, oneshot, watch, RwLock},
 };
 use tokio_tungstenite::tungstenite::{
     client::IntoClientRequest,
@@ -61,6 +61,11 @@ pub enum Error {
     /// Error in the internal MPSC channel.
     #[error("{0}")]
     MpscSend(#[from] mpsc::error::SendError<SubscriptionMessage<Value>>),
+
+    /// The websocket connection is closed, either because it was closed explicitly, or because it
+    /// died. The client can't be used anymore and has to be re-created.
+    #[error("The websocket connection is closed")]
+    ConnectionClosed,
 }
 
 type StreamsMap = HashMap<SubscriptionId, mpsc::Sender<SubscriptionMessage<Value>>>;
@@ -72,6 +77,7 @@ pub struct WebsocketClient {
     streams: Arc<RwLock<StreamsMap>>,
     requests: Arc<RwLock<RequestsMap>>,
     sender: RwLock<SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>,
+    closed: Arc<watch::Sender<bool>>,
     next_id: AtomicU64,
 }
 
@@ -113,10 +119,12 @@ impl WebsocketClient {
 
         let streams = Arc::new(RwLock::new(HashMap::new()));
         let requests = Arc::new(RwLock::new(HashMap::new()));
+        let closed = Arc::new(watch::channel(false).0);
 
         {
             let streams = Arc::clone(&streams);
             let requests = Arc::clone(&requests);
+            let closed = Arc::clone(&closed);
 
             tokio::spawn(async move {
                 while let Some(message_result) = ws_rx.next().await {
@@ -133,6 +141,11 @@ impl WebsocketClient {
                         }
                     }
                 }
+
+                // The connection ended - either cleanly, or because it died. Propagate that to
+                // everyone waiting on it, instead of leaving them pending forever.
+                log::debug!("Websocket connection ended, closing streams and pending requests");
+                Self::teardown(&streams, &requests, &closed).await;
             });
         }
 
@@ -141,6 +154,7 @@ impl WebsocketClient {
             sender: RwLock::new(ws_tx),
             streams,
             requests,
+            closed,
         })
     }
 
@@ -152,6 +166,46 @@ impl WebsocketClient {
     ///
     pub async fn with_url(url: Url) -> Result<Self, Error> {
         Self::new(url, None).await
+    }
+
+    /// Returns whether the connection is closed, i.e. whether it either died or was closed with
+    /// [`Client::close`]. A closed client can't be used anymore and has to be re-created.
+    pub fn is_closed(&self) -> bool {
+        *self.closed.borrow()
+    }
+
+    /// Resolves as soon as the connection is closed, i.e. as soon as it either dies or is closed
+    /// with [`Client::close`]. Resolves immediately if it is closed already.
+    ///
+    /// This allows detecting a dead connection without waiting for a request or a subscription to
+    /// fail:
+    ///
+    /// ```no_run
+    /// # async fn example(client: nimiq_jsonrpc_client::websocket::WebsocketClient) {
+    /// client.closed().await;
+    /// // Reconnect here.
+    /// # }
+    /// ```
+    pub async fn closed(&self) {
+        // This only fails if the sender was dropped, which can't happen while `self` is alive.
+        let _ = self.closed.subscribe().wait_for(|closed| *closed).await;
+    }
+
+    /// Marks the connection as closed and drops every subscription and request sender. This ends
+    /// all subscription streams and makes all pending requests resolve with
+    /// [`Error::OneshotRecv`].
+    ///
+    /// The closed flag is set before the maps are cleared: a registration that is racing with this
+    /// either observes the flag (and is rejected), or holds the respective lock and is thus
+    /// removed by the clear that follows.
+    async fn teardown(
+        streams: &Arc<RwLock<StreamsMap>>,
+        requests: &Arc<RwLock<RequestsMap>>,
+        closed: &watch::Sender<bool>,
+    ) {
+        closed.send_replace(true);
+        requests.write().await.clear();
+        streams.write().await.clear();
     }
 
     async fn handle_websocket_message(
@@ -218,17 +272,28 @@ impl Client for WebsocketClient {
 
         log::debug!("Sending request: {:?}", request);
 
-        self.sender
-            .write()
-            .await
-            .send(Message::binary(serde_json::to_vec(&request)?))
-            .await?;
+        let message = Message::binary(serde_json::to_vec(&request)?);
 
-        let (tx, rx) = oneshot::channel();
+        // Register the request *before* sending it: the response can arrive as soon as the send
+        // completes, and the reader task discards responses it can't match to a pending request.
+        let rx = {
+            let mut requests = self.requests.write().await;
 
-        let mut requests = self.requests.write().await;
-        requests.insert(request_id, tx);
-        drop(requests);
+            if self.is_closed() {
+                return Err(Error::ConnectionClosed);
+            }
+
+            let (tx, rx) = oneshot::channel();
+            requests.insert(request_id, tx);
+
+            rx
+        };
+
+        if let Err(e) = self.sender.write().await.send(message).await {
+            // The request was never sent, so nothing will ever resolve it.
+            self.requests.write().await.remove(&request_id);
+            return Err(e.into());
+        }
 
         let response = rx.await?;
         log::debug!("Received response: {:?}", response);
@@ -242,7 +307,18 @@ impl Client for WebsocketClient {
     {
         let (tx, mut rx) = mpsc::channel(16);
 
-        self.streams.write().await.insert(id, tx);
+        {
+            let mut streams = self.streams.write().await;
+
+            if self.is_closed() {
+                // This can't return an error, so signal the dead connection with a stream that
+                // has already ended.
+                log::error!("Can't subscribe to {}: the connection is closed", id);
+                return stream::empty().boxed();
+            }
+
+            streams.insert(id, tx);
+        }
 
         let stream = async_stream::stream! {
             while let Some(message) = rx.recv().await {
@@ -254,6 +330,11 @@ impl Client for WebsocketClient {
     }
 
     async fn disconnect_stream(&self, id: SubscriptionId) -> Result<(), Self::Error> {
+        if self.is_closed() {
+            // The connection is gone, so all streams ended already.
+            return Ok(());
+        }
+
         if let Some(tx) = self.streams.write().await.remove(&id) {
             log::debug!("Closing stream of subscription ID: {}", id);
             drop(tx);
@@ -277,5 +358,9 @@ impl Client for WebsocketClient {
                 reason: "".into(),
             })))
             .await;
+
+        // Tear down right away instead of waiting for the peer to answer the close handshake -
+        // it might never do so, and pending requests and streams must not hang on that.
+        Self::teardown(&self.streams, &self.requests, &self.closed).await;
     }
 }

--- a/client/tests/websocket_connection_loss.rs
+++ b/client/tests/websocket_connection_loss.rs
@@ -8,7 +8,10 @@
 use std::{future::Future, sync::Arc, time::Duration};
 
 use futures::{sink::SinkExt, stream::StreamExt};
-use nimiq_jsonrpc_client::{websocket::WebsocketClient, Client};
+use nimiq_jsonrpc_client::{
+    websocket::{Config, WebsocketClient},
+    Client,
+};
 use nimiq_jsonrpc_core::SubscriptionId;
 use serde_json::{json, Value};
 use tokio::net::{TcpListener, TcpStream};
@@ -165,4 +168,79 @@ async fn connection_loss_is_observable_without_a_pending_request() {
 
     bounded(client.closed()).await;
     assert!(client.is_closed());
+}
+
+/// A connection that is silently blackholed - no close frame, no reset, nothing to observe - can
+/// only be detected by noticing that nothing comes back anymore.
+#[tokio::test(flavor = "multi_thread")]
+async fn blackholed_connection_is_detected_by_the_heartbeat() {
+    let url = serve(|mut ws| async move {
+        let request = next_request(&mut ws).await;
+        respond(&mut ws, &request["id"], json!(1)).await;
+
+        // Stop reading and writing, but hold the connection open: pings are never answered and
+        // the client never sees an error or an EOF.
+        std::future::pending::<()>().await;
+    })
+    .await;
+
+    let client = Arc::new(
+        WebsocketClient::new_with_config(
+            url,
+            None,
+            Config {
+                ping_interval: Some(Duration::from_millis(50)),
+                ping_timeout: Duration::from_millis(300),
+            },
+        )
+        .await
+        .unwrap(),
+    );
+
+    let subscription: u64 = client.send_request("subscribe", &()).await.unwrap();
+    let mut stream = client
+        .connect_stream::<u64>(SubscriptionId::Number(subscription))
+        .await;
+
+    let pending = tokio::spawn({
+        let client = Arc::clone(&client);
+        async move { client.send_request::<_, u64>("never_answered", &()).await }
+    });
+
+    assert_eq!(bounded(stream.next()).await, None);
+    assert!(bounded(pending).await.unwrap().is_err());
+    assert!(client.is_closed());
+}
+
+/// The heartbeat must not kill a connection that is merely idle. The server answers pings with
+/// pongs, which is enough to keep it alive.
+#[tokio::test(flavor = "multi_thread")]
+async fn heartbeat_keeps_an_idle_connection_alive() {
+    let url = serve(|mut ws| async move {
+        // Polling the stream is what makes tungstenite answer pings automatically.
+        loop {
+            let request = next_request(&mut ws).await;
+            respond(&mut ws, &request["id"], json!("alive")).await;
+        }
+    })
+    .await;
+
+    let client = WebsocketClient::new_with_config(
+        url,
+        None,
+        Config {
+            ping_interval: Some(Duration::from_millis(50)),
+            ping_timeout: Duration::from_millis(300),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Stay completely idle for many ping intervals, well past the timeout.
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+
+    assert!(!client.is_closed());
+
+    let reply: String = client.send_request("still_alive", &()).await.unwrap();
+    assert_eq!(reply, "alive");
 }

--- a/client/tests/websocket_connection_loss.rs
+++ b/client/tests/websocket_connection_loss.rs
@@ -1,0 +1,168 @@
+#![cfg(feature = "websocket-client")]
+//! Regression tests for connection teardown in [`WebsocketClient`].
+//!
+//! When the websocket connection dies, every subscription stream must end and every in-flight
+//! request must resolve with an error. Before this was fixed, both hung forever because the
+//! senders lived in maps owned by the client, which the reader task could not drop.
+
+use std::{future::Future, sync::Arc, time::Duration};
+
+use futures::{sink::SinkExt, stream::StreamExt};
+use nimiq_jsonrpc_client::{websocket::WebsocketClient, Client};
+use nimiq_jsonrpc_core::SubscriptionId;
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio_tungstenite::{accept_async, tungstenite::Message, WebSocketStream};
+use url::Url;
+
+/// Fails the test instead of hanging forever. The assertions below are on the values the client
+/// produces, never on this timeout firing.
+async fn bounded<F: Future>(f: F) -> F::Output {
+    tokio::time::timeout(Duration::from_secs(10), f)
+        .await
+        .expect("client did not react to the connection being closed")
+}
+
+/// Reads the next JSON-RPC message the client sent.
+async fn next_request(ws: &mut WebSocketStream<TcpStream>) -> Value {
+    loop {
+        let message = ws
+            .next()
+            .await
+            .expect("client closed the connection")
+            .expect("websocket error");
+
+        match message {
+            Message::Text(text) => return serde_json::from_str(&text).unwrap(),
+            Message::Binary(bytes) => return serde_json::from_slice(&bytes).unwrap(),
+            _ => continue,
+        }
+    }
+}
+
+async fn respond(ws: &mut WebSocketStream<TcpStream>, id: &Value, result: Value) {
+    let response = json!({ "jsonrpc": "2.0", "result": result, "id": id });
+    ws.send(Message::text(response.to_string())).await.unwrap();
+}
+
+async fn notify(ws: &mut WebSocketStream<TcpStream>, subscription: u64, result: Value) {
+    let notification = json!({
+        "jsonrpc": "2.0",
+        "method": "notification",
+        "params": { "subscription": subscription, "result": result },
+    });
+    ws.send(Message::text(notification.to_string()))
+        .await
+        .unwrap();
+}
+
+/// Binds a server on a random port and hands each accepted connection to `handler`.
+async fn serve<F, Fut>(handler: F) -> Url
+where
+    F: FnOnce(WebSocketStream<TcpStream>) -> Fut + Send + 'static,
+    Fut: Future<Output = ()> + Send,
+{
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = Url::parse(&format!("ws://{}/", listener.local_addr().unwrap())).unwrap();
+
+    tokio::spawn(async move {
+        let (tcp, _) = listener.accept().await.unwrap();
+        handler(accept_async(tcp).await.unwrap()).await;
+    });
+
+    url
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connection_loss_ends_streams_and_fails_pending_requests() {
+    let url = serve(|mut ws| async move {
+        // The subscribe call, which we answer with the subscription ID.
+        let request = next_request(&mut ws).await;
+        respond(&mut ws, &request["id"], json!(1)).await;
+
+        // The second call is never answered: it is the request that must be in flight when the
+        // connection dies.
+        let _ = next_request(&mut ws).await;
+
+        // Prove the subscription is live, then drop the TCP connection without a close handshake.
+        notify(&mut ws, 1, json!(42)).await;
+        drop(ws);
+    })
+    .await;
+
+    let client = Arc::new(WebsocketClient::with_url(url).await.unwrap());
+
+    let subscription: u64 = client.send_request("subscribe", &()).await.unwrap();
+    let mut stream = client
+        .connect_stream::<u64>(SubscriptionId::Number(subscription))
+        .await;
+
+    let pending = tokio::spawn({
+        let client = Arc::clone(&client);
+        async move { client.send_request::<_, u64>("never_answered", &()).await }
+    });
+
+    assert_eq!(bounded(stream.next()).await, Some(42));
+
+    // The connection is gone: the stream must end and the in-flight request must fail.
+    assert_eq!(bounded(stream.next()).await, None);
+    assert!(bounded(pending).await.unwrap().is_err());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn explicit_close_ends_streams_and_fails_pending_requests() {
+    let url = serve(|mut ws| async move {
+        let request = next_request(&mut ws).await;
+        respond(&mut ws, &request["id"], json!(1)).await;
+
+        // Never answer anything else, and never reply to the close frame either.
+        std::future::pending::<()>().await;
+    })
+    .await;
+
+    let client = Arc::new(WebsocketClient::with_url(url).await.unwrap());
+
+    let subscription: u64 = client.send_request("subscribe", &()).await.unwrap();
+    let mut stream = client
+        .connect_stream::<u64>(SubscriptionId::Number(subscription))
+        .await;
+
+    let pending = tokio::spawn({
+        let client = Arc::clone(&client);
+        async move { client.send_request::<_, u64>("never_answered", &()).await }
+    });
+
+    client.close().await;
+
+    assert_eq!(bounded(stream.next()).await, None);
+    assert!(bounded(pending).await.unwrap().is_err());
+
+    // A closed client must fail fast rather than register into a dead connection.
+    assert!(bounded(client.send_request::<_, u64>("after_close", &()))
+        .await
+        .is_err());
+    let mut after_close = client
+        .connect_stream::<u64>(SubscriptionId::Number(2))
+        .await;
+    assert_eq!(bounded(after_close.next()).await, None);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connection_loss_is_observable_without_a_pending_request() {
+    let url = serve(|mut ws| async move {
+        let request = next_request(&mut ws).await;
+        respond(&mut ws, &request["id"], json!(1)).await;
+
+        // Drop the TCP connection without a close handshake.
+        drop(ws);
+    })
+    .await;
+
+    let client = WebsocketClient::with_url(url).await.unwrap();
+    assert!(!client.is_closed());
+
+    let _: u64 = client.send_request("subscribe", &()).await.unwrap();
+
+    bounded(client.closed()).await;
+    assert!(client.is_closed());
+}


### PR DESCRIPTION
Stacked on #72 — targets `fix/websocket-connection-teardown`, not `master`. Review that one first; this diff only makes sense on top of it.

## Why this is needed on top of #72

#72 tears the connection down when the reader loop ends. That covers deaths that are **observable** — a reset, a close, an EOF. It does nothing for a connection that is silently blackholed:

| | what the client sees | covered by #72 |
|---|---|---|
| Server restart, process kill, RST/FIN | socket errors or EOFs, reader loop ends | ✅ |
| Firewall / LB drops an idle flow, laptop sleeps, route changes | **nothing, ever** | ❌ |

In the second case `ws_rx.next().await` stays pending forever, the reader loop never ends, teardown never runs, and subscriptions and pending requests hang exactly as they did before #72.

There is no way to detect this without a clock — silence is indistinguishable from idleness. That is why this adds a timeout, where #72 deliberately refused to.

## What it does

Send a websocket ping every `ping_interval`; record when the last frame was received; once nothing has arrived for `ping_timeout`, run the **same `teardown`** the reader task runs. Blackhole detection is a second trigger for the existing mechanism, not a second code path.

Servers answer pings automatically (tungstenite and axum both do), so this needs no server-side support. The traffic also keeps middleboxes from evicting an idle connection in the first place, which matters behind an nginx or ALB with a 60s idle timeout.

The heartbeat task exits via the `closed` watch, so it doesn't outlive the connection or keep the sink alive.

`sender` becomes an `Arc<RwLock<...>>` so the heartbeat can share it. `tokio/time` is added to the `websocket-client` feature.

### Configuration

```rust
pub struct Config {
    pub ping_interval: Option<Duration>, // None disables the heartbeat
    pub ping_timeout: Duration,
}
```

`new` uses `Config::default()` — ping every 15s, dead after 45s of silence. `new_with_config` takes an explicit one.

## Commits

1. **`Don't parse websocket control frames as JSON-RPC`** — a prerequisite, and the `FIXME` that was already sitting on that line. `handle_websocket_message` fed every frame to `into_text` and then the JSON-RPC parser; for a ping or pong that returns the payload, so it got parsed as JSON and logged an error. Harmless today because nothing sends pings — and broken the moment this PR does. No test: the only effect is a spurious log line, not observable through the client's API.
2. **`Detect blackholed websocket connections with a heartbeat`** — the work above.

## Tests

- **`blackholed_connection_is_detected_by_the_heartbeat`** — server completes the handshake, answers one request, then stops reading and writing while holding the socket open. No error, no EOF, nothing observable. Asserts the subscription stream ends, the in-flight request returns `Err`, and `is_closed()` is true.
- **`heartbeat_keeps_an_idle_connection_alive`** — server polls the stream (so tungstenite auto-pongs) but sends nothing on its own. Asserts the client survives five timeout windows of total idleness and still serves a request.

Mutation-checked, and the two tests catch **different** failures: removing the heartbeat entirely fails only the blackhole test, while running the timer but sending no pings fails only the idle test. So the pings are proven load-bearing, not just the timer. 10 consecutive runs clean; `fmt`, `clippy --workspace --all-targets --all-features` and `test --workspace --all-features` all clean.

## Notes for reviewers

- **The heartbeat is on by default.** Existing callers start pinging, and a connection that previously hung silently will now be closed. That is the point, but it is a behaviour change on `new()` — say the word and the default becomes `ping_interval: None`.
- **The defaults are guesses.** 15s/45s suits a 60s LB idle timeout. Worth setting from your actual deployment before merging.
- This is option B from the discussion. TCP keepalive (option A) was rejected as more work for strictly less coverage: it can't see a wedged server process, since the kernel answers probes regardless. Server-side pings (option C) are complementary — they let the *server* detect dead clients — and are not implemented here.
- The wasm client can do neither: the browser WebSocket API exposes no ping and no socket options. Detecting a blackholed connection there needs an application-level JSON-RPC ping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJyT5cTdmHXyr34Pfcd8y7